### PR TITLE
feat(calendar): skip weekends and disable weekend selection

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/newui/page.tsx
+++ b/src/app/newui/page.tsx
@@ -402,23 +402,6 @@ function NewUiPageContent() {
 
             <SearchInput value={filterState.search} onChange={handleSearchChange} />
 
-            <div className="flex flex-wrap gap-2 md:hidden">
-              <Button
-                variant={isSameDay(selectedDate, schoolToday) ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setDateAndTrack(schoolToday, 'newui_today_mobile')}
-              >
-                Heute {formatChipDate(schoolToday)}
-              </Button>
-              <Button
-                variant={isSameDay(selectedDate, schoolTomorrow) ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => setDateAndTrack(schoolTomorrow, 'newui_tomorrow_mobile')}
-              >
-                Morgen {formatChipDate(schoolTomorrow)}
-              </Button>
-            </div>
-
             {stats.hasActiveFilters ? (
               <div className="hidden md:block">
                 <Button variant="ghost" size="sm" onClick={handleClearAllFilters}>


### PR DESCRIPTION
Add weekend awareness to the calendar widget and prevent selecting
weekend days. Introduce isWeekend on date models, a helper to detect
weekends, and normalizeSchoolDay to advance/retreat a date to the next
non-weekend day. Use that normalization in keyboard and click handlers
so navigation (arrow/home/end/offsets) lands on school days only.
Mark weekend cells as disabled/aria-disabled and style them as muted
and unselectable. Also update keyboard navigation to pass direction
so normalization can move forward or backward appropriately.

chore(types): adjust next types import for dev build

Change next-env.d.ts to import the dev routes types path
(.next/dev/types/routes.d.ts) so the TypeScript environment resolves
generated route types correctly during development.

refactor(ui): remove mobile quick-date buttons

Remove the "Heute" and "Morgen" quick-select mobile buttons from the
new UI page (hidden on md and up). These were removed in favor of the
updated calendar behavior and to simplify the mobile header.